### PR TITLE
Angel Ring Warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,8 +142,8 @@ dependencies {
     // For more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
-    runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${minecraft_version}-${curios_version}")
-    compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${minecraft_version}-${curios_version}:api")
+    runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
+    compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
 }
 
 // Example for how to get properties into the manifest for reading by the runtime..

--- a/src/main/java/dev/denismasterherobrine/angelring/compat/curios/AbstractRingCurio.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/compat/curios/AbstractRingCurio.java
@@ -1,6 +1,7 @@
 package dev.denismasterherobrine.angelring.compat.curios;
 
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.LivingEntity;
@@ -18,6 +19,7 @@ import top.theillusivec4.curios.api.type.capability.ICurio;
 import java.util.Optional;
 
 public abstract class AbstractRingCurio implements ICurio {
+    private static final ClientboundSetActionBarTextPacket packet = new ClientboundSetActionBarTextPacket(Component.translatable("angelring.warning"));
     private final Item item;
     public AbstractRingCurio(Item item) {
         this.item = item;  // I have the suspicion that this results in a circular reference but yolo.
@@ -74,6 +76,7 @@ public abstract class AbstractRingCurio implements ICurio {
     abstract protected boolean checkIfAllowedToFly(Player player, ItemStack stack);
     abstract protected Component getNotAbleToFlyMessage();
     abstract protected void payForFlight(Player player, ItemStack stack);
+    abstract protected boolean warnPlayer(Player player, ItemStack stack);
 
     @Override
     public void curioTick(SlotContext slotContext) {
@@ -99,6 +102,7 @@ public abstract class AbstractRingCurio implements ICurio {
             if (player.getAbilities().mayfly && player.getAbilities().flying) {
                 ClassicAngelRingIntegration.once = true;
                 payForFlight(player, stack);
+                if (player instanceof ServerPlayer serverPlayer && warnPlayer(player, stack)) serverPlayer.connection.send(packet);
             }
         }
     }

--- a/src/main/java/dev/denismasterherobrine/angelring/compat/curios/ClassicAngelRingIntegration.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/compat/curios/ClassicAngelRingIntegration.java
@@ -74,6 +74,11 @@ public class ClassicAngelRingIntegration {
                     once = false;
                 }
             }
+
+            @Override
+            protected boolean warnPlayer(Player player, ItemStack stack) {
+                return player.experienceLevel <= Configuration.XPWarningLevel.get();
+            }
         };
 
         return new ICapabilityProvider() {

--- a/src/main/java/dev/denismasterherobrine/angelring/compat/curios/EnergeticAngelRingIntegration.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/compat/curios/EnergeticAngelRingIntegration.java
@@ -55,6 +55,12 @@ public class EnergeticAngelRingIntegration {
             protected void payForFlight(Player player, ItemStack stack) {
                 getEnergyStorage(getStack()).extractEnergy(fePerTick, false);
             }
+
+            @Override
+            protected boolean warnPlayer(Player player, ItemStack stack) {
+                IEnergyStorage energy = getEnergyStorage(stack);
+                return ((double) energy.getEnergyStored())/energy.getMaxEnergyStored()*100 <= Configuration.EnergyWarningPercentage.get();
+            }
         };
 
         EnergyItem energyItem = new EnergyItem(stack, Configuration.EnergeticFECapacity.get());

--- a/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/HardenedAngelRingIntegration.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/HardenedAngelRingIntegration.java
@@ -55,6 +55,12 @@ public class HardenedAngelRingIntegration {
             protected void payForFlight(Player player, ItemStack stack) {
                 getEnergyStorage(getStack()).extractEnergy(fePerTick, false);
             }
+
+            @Override
+            protected boolean warnPlayer(Player player, ItemStack stack) {
+                IEnergyStorage energy = getEnergyStorage(stack);
+                return ((double) energy.getEnergyStored())/energy.getMaxEnergyStored()*100 <= Configuration.EnergyWarningPercentage.get();
+            }
         };
 
         EnergyItem energyItem = new EnergyItem(stack, Configuration.HardenedCapacity.get());

--- a/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/LeadstoneAngelRingIntegration.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/LeadstoneAngelRingIntegration.java
@@ -52,6 +52,12 @@ public class LeadstoneAngelRingIntegration {
             protected void payForFlight(Player player, ItemStack stack) {
                 getEnergyStorage(getStack()).extractEnergy(fePerTick, false);
             }
+
+            @Override
+            protected boolean warnPlayer(Player player, ItemStack stack) {
+                IEnergyStorage energy = getEnergyStorage(stack);
+                return ((double) energy.getEnergyStored())/energy.getMaxEnergyStored()*100 <= Configuration.EnergyWarningPercentage.get();
+            }
         };
 
         EnergyItem energyItem = new EnergyItem(stack, Configuration.LeadstoneCapacity.get());

--- a/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/ReinforcedAngelRingIntegration.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/ReinforcedAngelRingIntegration.java
@@ -52,6 +52,12 @@ public class ReinforcedAngelRingIntegration {
             protected void payForFlight(Player player, ItemStack stack) {
                 getEnergyStorage(getStack()).extractEnergy(fePerTick, false);
             }
+
+            @Override
+            protected boolean warnPlayer(Player player, ItemStack stack) {
+                IEnergyStorage energy = getEnergyStorage(stack);
+                return ((double) energy.getEnergyStored())/energy.getMaxEnergyStored()*100 <= Configuration.EnergyWarningPercentage.get();
+            }
         };
 
         EnergyItem energyItem = new EnergyItem(stack, Configuration.ReinforcedCapacity.get());

--- a/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/ResonantAngelRingIntegration.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/compat/thermal/ResonantAngelRingIntegration.java
@@ -52,6 +52,12 @@ public class ResonantAngelRingIntegration {
             protected void payForFlight(Player player, ItemStack stack) {
                 getEnergyStorage(getStack()).extractEnergy(fePerTick, false);
             }
+
+            @Override
+            protected boolean warnPlayer(Player player, ItemStack stack) {
+                IEnergyStorage energy = getEnergyStorage(stack);
+                return ((double) energy.getEnergyStored())/energy.getMaxEnergyStored()*100 <= Configuration.EnergyWarningPercentage.get();
+            }
         };
 
         EnergyItem energyItem = new EnergyItem(stack, Configuration.ResonantCapacity.get());

--- a/src/main/java/dev/denismasterherobrine/angelring/config/Configuration.java
+++ b/src/main/java/dev/denismasterherobrine/angelring/config/Configuration.java
@@ -34,6 +34,9 @@ public class Configuration {
     public static ForgeConfigSpec.IntValue ResonantFEPerTick;
     public static ForgeConfigSpec.IntValue ResonantCapacity;
 
+    public static ForgeConfigSpec.IntValue XPWarningLevel;
+    public static ForgeConfigSpec.IntValue EnergyWarningPercentage;
+
     static {
         COMMON_BUILDER.comment("General Angel Ring 2 configuration options.").push(CATEGORY_GENERAL);
 
@@ -57,6 +60,9 @@ public class Configuration {
 
         ResonantFEPerTick = COMMON_BUILDER.comment("Define how much FE the Resonant Angel Ring will drain every tick while flying.").defineInRange("ResonantFEPerTick", 50, 1, 2147483647);
         ResonantCapacity = COMMON_BUILDER.comment("Define how much FE the Resonant Angel Ring can store.").defineInRange("ResonantFECapacity", 16000000, 1, 2147483647);
+
+        XPWarningLevel = COMMON_BUILDER.comment("Defines at what XP Level to start displaying a warning of low XP for the Classic Angel Ring. Set to -1 to disable.").defineInRange("XPWarningLevel", 3, -1, 2147483647);
+        EnergyWarningPercentage = COMMON_BUILDER.comment("Defines at what percentage to start displaying a warning of low power for Energy Angel Rings. Set to -1 to disable.").defineInRange("EnergyWarningPercentage", 5, -1, 100);
 
         COMMON_BUILDER.pop();
         COMMON_CONFIG = COMMON_BUILDER.build();

--- a/src/main/resources/assets/angelring/lang/en_us.json
+++ b/src/main/resources/assets/angelring/lang/en_us.json
@@ -18,5 +18,6 @@
   "item.angelring.reinforced_angel_ring": "Reinforced Angel Ring",
   "item.angelring.resonant_angel_ring": "Resonant Angel Ring",
   "curios.identifier.angelring": "Angel Ring",
-  "itemGroup.angelring2": "Angel Ring 2"
+  "itemGroup.angelring2": "Angel Ring 2",
+  "angelring.warning": "§cYour angel ring is running low on power!"
 }


### PR DESCRIPTION
Added angel ring warning which triggers when power is low.

![image](https://github.com/DenisMasterHerobrine/AngelRing/assets/20095065/b5acae8b-f9f6-4a79-be3e-6b6304db8726)
- Message appears in the Action Bar.
- Message pulls from `angelring.warning`. Only `en_us.json` was updated, I cannot speak the other languages.
- Added configuration options:
  - `XPWarningLevel: 3`: When to start warning players of low angel ring power, based on Player's XP Level, defaults to 3.
  - `EnergyWarningPercentage: 5`: Percentage to start warning players of low angel ring power, based on the energy within the ring, defaults to 5%.
  - Both configuration options can be disabled by setting the value to `-1`.